### PR TITLE
Fix handling of multiline dependency list with a single-line comment inside

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -41,14 +41,17 @@ class ReferenceProvider {
 		let list, result;
 		const array = /\[[^\]]*\]/gi;
 		const params = /function\s*\([^)]*/gi;
+		// Remove comments, which would make JSON.parse fail. Not the optimal solution;
+		// see https://stackoverflow.com/a/15123777/623816 for more information.
+		const cleanedStr = str.replace(/\/\*[\s\S]*?\*\/|([^\\:]|^)\/\/.*$/gm, '');
 
-		let m = array.exec(str);
+		let m = array.exec(cleanedStr);
 
 		if (m) {
 			list = JSON.parse(m[0].split('\'').join('"'));
 		}
 
-		m = params.exec(str);
+		m = params.exec(cleanedStr);
 
 		if (m) {
 			const test = /([^\s,]+)/g;

--- a/testFiles/basicMultilineWithComment.js
+++ b/testFiles/basicMultilineWithComment.js
@@ -1,0 +1,7 @@
+require(['moduleA', // first module 
+            'moduleB'], function(a, b) {
+    var foo = a;
+    var bar = b;
+    foo.baz();
+    bar.prop;
+});


### PR DESCRIPTION
Aims to fix #44.

[Edge cases of the regex used](https://gist.github.com/DesignByOnyx/05c2241affc9dc498379e0d819c4d756) should not occur within the `define`  or `require` statements.