### PR TITLE
Allows custom define and require definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,13 @@ Example:
 
 This will ensure, that a module reference like "css!views/panel" will be handled as "css!views/panel.css" before resolving the actual module path.
 
+If you for some reason are using custom `define` and `require` names, those can be configured with
+
+    "requireModuleSupport.requireName": "requireCustomName",
+    "requireModuleSupport.defineName": "defineCustomName"
+
+And this will resolve correctly.
+
 ### RequireJS Config Files
 
 RequireJS configuration properties like `paths`, `bundles` and `config` are usually maintained in a separate file in a single `require.config()` statement. This file can be evaluated, when the project is loaded on debug pages, when the project is built (for root components) and in other situations - like this editor plugin.

--- a/extension.js
+++ b/extension.js
@@ -40,7 +40,10 @@ class ReferenceProvider {
 	 * @returns {Array} containing objects
 	 */
 	getRequireOrDefineStatements (str) {
-		let match = /^[ \t]*(define|require)\s*\(([^)]*)/mgi;
+		let requireModuleSupport = vscode.workspace.getConfiguration('requireModuleSupport');
+		let requireName = requireModuleSupport.get('requireName') || 'require';
+		let defineName = requireModuleSupport.get('defineName') || 'define';
+		let match = new RegExp(`^[ \t]*(${defineName}|${requireName})\s*\(([^)]*)`, 'mgi');
 
 		let list = [];
 		let searchResult;

--- a/extension.js
+++ b/extension.js
@@ -43,7 +43,7 @@ class ReferenceProvider {
 		let requireModuleSupport = vscode.workspace.getConfiguration('requireModuleSupport');
 		let requireName = requireModuleSupport.get('requireName') || 'require';
 		let defineName = requireModuleSupport.get('defineName') || 'define';
-		let match = new RegExp(`^[ \t]*(${defineName}|${requireName})\s*\(([^)]*)`, 'mgi');
+		let match = new RegExp('^[ \t]*(' + defineName + '|' + requireName + ')s*\\(([^)]*)', 'mgi');
 
 		let list = [];
 		let searchResult;
@@ -419,6 +419,9 @@ class ReferenceProvider {
 				// TODO: also consider window. defined globals
 				// Dont have a parent and have a constructor, follow the constructor
 
+				let requireModuleSupport = vscode.workspace.getConfiguration('requireModuleSupport');
+				let requireName = requireModuleSupport.get('requireName') || 'require';
+
 				if (constructors.length && !haveParent) {
 					let constructorName = document.getText(document.getWordRangeAtPosition(constructors[0].range._start));
 					// Break search in case the instance and the constructor have the same name
@@ -428,8 +431,8 @@ class ReferenceProvider {
 						resolve(undefined);
 
 						return;
-					} else if (constructorName === 'require') { // Module is used commonJS style - instead of complicating module list extraction, directly navigate
-						let re = /(require)\s*\(\s*(['"]*)/gi;
+					} else if (constructorName === requireName) { // Module is used commonJS style - instead of complicating module list extraction, directly navigate
+						let re = new RegExp(`(${requireName})s*\\(s*(['"]*)`, 'gi');
 
 						re.lastIndex = document.offsetAt(constructors[0].range._start);
 						let stringOffset = re.exec(fullText)[0].length;


### PR DESCRIPTION
This pull requests allows for custom `require` and `define` definitions. This is relevant in relation to e.g. [curl.js](https://github.com/cujojs/curl) (yes, I'm aware that it's highly outdated, but we're still stuck using it in our current architecture :disappointed: ), where you can rename the `require` and `define` keywords to avoid collision with e.g. vendor specific versions.